### PR TITLE
Remove unused tags references to fix database schema compatibility

### DIFF
--- a/backend/db/queries.go
+++ b/backend/db/queries.go
@@ -12,7 +12,7 @@ func (db *DB) GetPhotosNeedingMetadata(albumID *string, limit, offset int) ([]mo
 	query := `
 		SELECT 
 			p.id, p.created_at, p.updated_at, p.owner_id, p.old_album_id,
-			p.title, p.description, p.tags, p.license, p.is_starred,
+			p.title, p.description, p.license, p.is_starred,
 			p.iso, p.make, p.model, p.lens, p.aperture, p.shutter, p.focal,
 			p.latitude, p.longitude, p.altitude, p.img_direction, p.location,
 			p.taken_at, p.type, p.filesize, p.checksum,
@@ -71,7 +71,7 @@ func (db *DB) GetPhotosNeedingMetadata(albumID *string, limit, offset int) ([]mo
 		var photo models.PhotoWithSizeVariants
 		err := rows.Scan(
 			&photo.ID, &photo.CreatedAt, &photo.UpdatedAt, &photo.OwnerID, &photo.AlbumID,
-			&photo.Title, &photo.Description, &photo.Tags, &photo.License, &photo.IsStarred,
+			&photo.Title, &photo.Description, &photo.License, &photo.IsStarred,
 			&photo.ISO, &photo.Make, &photo.Model, &photo.Lens, &photo.Aperture, &photo.Shutter, &photo.Focal,
 			&photo.Latitude, &photo.Longitude, &photo.Altitude, &photo.ImgDirection, &photo.Location,
 			&photo.TakenAt, &photo.Type, &photo.Filesize, &photo.Checksum,
@@ -90,7 +90,7 @@ func (db *DB) GetPhotoByID(id string) (*models.PhotoWithSizeVariants, error) {
 	query := `
 		SELECT 
 			p.id, p.created_at, p.updated_at, p.owner_id, p.old_album_id,
-			p.title, p.description, p.tags, p.license, p.is_starred,
+			p.title, p.description, p.license, p.is_starred,
 			p.iso, p.make, p.model, p.lens, p.aperture, p.shutter, p.focal,
 			p.latitude, p.longitude, p.altitude, p.img_direction, p.location,
 			p.taken_at, p.type, p.filesize, p.checksum,
@@ -106,7 +106,7 @@ func (db *DB) GetPhotoByID(id string) (*models.PhotoWithSizeVariants, error) {
 	var photo models.PhotoWithSizeVariants
 	err := db.QueryRow(query, id).Scan(
 		&photo.ID, &photo.CreatedAt, &photo.UpdatedAt, &photo.OwnerID, &photo.AlbumID,
-		&photo.Title, &photo.Description, &photo.Tags, &photo.License, &photo.IsStarred,
+		&photo.Title, &photo.Description, &photo.License, &photo.IsStarred,
 		&photo.ISO, &photo.Make, &photo.Model, &photo.Lens, &photo.Aperture, &photo.Shutter, &photo.Focal,
 		&photo.Latitude, &photo.Longitude, &photo.Altitude, &photo.ImgDirection, &photo.Location,
 		&photo.TakenAt, &photo.Type, &photo.Filesize, &photo.Checksum,

--- a/backend/models/photo.go
+++ b/backend/models/photo.go
@@ -19,7 +19,6 @@ type Photo struct {
 	AlbumID      *string    `json:"album_id" db:"old_album_id"`
 	Title        string     `json:"title" db:"title"`
 	Description  *string    `json:"description" db:"description"`
-	Tags         *string    `json:"tags" db:"tags"`
 	License      string     `json:"license" db:"license"`
 	IsStarred    bool       `json:"is_starred" db:"is_starred"`
 	ISO          *string    `json:"iso" db:"iso"`


### PR DESCRIPTION
## Summary
Fixes database error: `Unknown column 'p.tags' in 'SELECT'` by removing unused tags references from the codebase.

## Analysis
- The `tags` field was defined in the Photo model and selected in database queries but never actually used
- No UI components, API handlers, or frontend code referenced tags  
- The underlying database schema has been updated and no longer includes the tags column
- This was causing runtime errors when querying photos

## Changes
- Remove `Tags` field from `Photo` struct in `backend/models/photo.go`
- Remove `p.tags` from SELECT statements in both `GetPhotosNeedingMetadata` and `GetPhotoByID` queries
- Remove `&photo.Tags` from corresponding Scan operations in `backend/db/queries.go`

## Test plan
- [x] Go code compiles successfully 
- [x] No references to tags remain in the codebase
- [x] All existing functionality preserved (tags were unused)

🤖 Generated with [Claude Code](https://claude.ai/code)